### PR TITLE
Add exclude labels option

### DIFF
--- a/__tests__/__snapshots__/github.test.ts.snap
+++ b/__tests__/__snapshots__/github.test.ts.snap
@@ -34,6 +34,11 @@ Array [
                   }
                 }
               }
+              labels(first: 10) {
+                nodes {
+                  name
+                }
+              }
             }
             totalCount
           }

--- a/__tests__/messages.test.ts
+++ b/__tests__/messages.test.ts
@@ -1,6 +1,13 @@
 import * as core from '@actions/core'
+import { format } from 'timeago.js'
 import { formatSinglePR, formatSlackMessage } from '../src/message'
 import { PullRequest } from '../src/github'
+
+jest.mock('timeago.js')
+
+beforeEach(() => {
+  (format as jest.Mock).mockImplementationOnce(() => '6 days ago')
+})
 
 const mockPR: PullRequest = {
   id: 'MDExOlB1bGxSZXF1ZXN0Mzg4ODU2OTU0',
@@ -31,6 +38,13 @@ const mockPR: PullRequest = {
       },
     ],
   },
+  labels: {
+    nodes: [
+      {
+        name: 'stuff'
+      }
+    ]
+  }
 }
 
 test('formats single PR', () => {

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,8 @@ inputs:
   notify-empty:
     description: 'Should a message be sent when there are no PRs ready?'
     default: 'true'
+  exclude-labels:
+    description: 'Comma seperated list of labels to exclude from PR reports'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/github.ts
+++ b/src/github.ts
@@ -22,11 +22,13 @@ export interface PullRequest {
   isDraft: boolean
   reviews: {
     totalCount: number
-    nodes: [
-      {
-        state: keyof typeof ReviewStates
-      },
-    ]
+    nodes:
+      | [
+          {
+            state: keyof typeof ReviewStates
+          },
+        ]
+      | []
   }
   comments: {
     totalCount: number
@@ -36,6 +38,15 @@ export interface PullRequest {
   }
   commits: {
     nodes: object[]
+  }
+  labels: {
+    nodes:
+      | [
+          {
+            name: string
+          },
+        ]
+      | []
   }
 }
 
@@ -74,6 +85,11 @@ export async function queryPRs(token: string): Promise<GraphQLResponse> {
                       state
                     }
                   }
+                }
+              }
+              labels(first: 10) {
+                nodes {
+                  name
                 }
               }
             }


### PR DESCRIPTION
Closes #7 
Add `exclude-labels` option to exclude PRs with a specific label from the PR reporter message.